### PR TITLE
Switched `opm token` to use a file instead of environmental variable

### DIFF
--- a/main.odin
+++ b/main.odin
@@ -25,61 +25,17 @@ main :: proc() {
 }
 
 _main :: proc() {
-	publish()
-	if true do return
-
-	switch len(os.args) {
-	case 1:
+	if len(os.args) < 2 {
 		fmt.println("OPM Commands:")
 		fmt.println("`opm publish` - publish the current directory")
-		fmt.println("`opm token OPM_TOKEN_VALUE` - sets environment variable for auth token")
-	case 2:
-		if os.args[1] != "publish" {fmt.println("invalid argument, expected `publish`")} else {
-			publish()
-		}
+		fmt.println("`opm token set OPM_TOKEN_VALUE` - sets environment variable for auth token")
+		return
+	}
 
-	case 3:
-		if os.args[1] != "token" {fmt.println("invalid argument, expected `token`")} else {
-			token_value := os.args[2]
-
-			when ODIN_OS == .Linux {
-				token_line: string = fmt.tprintf("export OPM_TOKEN=\"%s\"", token_value)
-				replaced_existing := false
-				spaces: string
-				token_line_padded: string
-
-				home_dir := os.get_env("HOME");defer delete(home_dir)
-				strs := []string{home_dir, "/.bashrc"}
-				bashrc_path := strings.concatenate(strs)
-				file, ok := os.read_entire_file(bashrc_path);defer delete(file)
-				lines := strings.split(string(file), "\n");defer delete(lines)
-				for i := 0; i < len(lines); i += 1 {
-					if strings.contains(string(lines[i]), "export OPM_TOKEN") {
-						if len(lines[i]) > len(token_line) {
-							spaces = strings.repeat(" ", len(lines[i]) - len(token_line))
-							join := []string{token_line, spaces}
-							token_line_padded := strings.join(join, "")
-							lines[i] = token_line_padded
-						} else {
-							lines[i] = token_line
-						}
-						replaced_existing = true
-						break
-					}
-				}
-				data := strings.join(lines, "\n");delete(data)
-				h, e := os.open(bashrc_path, os.O_RDWR, 0o644)
-				os.seek(h, 0, os.SEEK_SET)
-				os.write_string(h, data)
-				if !replaced_existing {
-					os.write_string(h, "\n")
-					os.write_string(h, token_line)
-				}
-				if spaces != "" {delete(spaces)}
-				if token_line_padded != "" {delete(token_line_padded)}
-			} else {
-				panic("Feature not implemented for this OS.")
-			}
-		}
+	switch os.args[1] {
+		case "publish": publish()
+		case "token": token()
+		case "help": os.args = os.args[1:];_main()
+		case: fmt.printf("\"%s\" isn't a known subcommand, type `opm` for help\n", os.args[1])
 	}
 }

--- a/main.odin
+++ b/main.odin
@@ -8,10 +8,18 @@ import "core:os"
 // import "core:os/os2"
 import "core:path/filepath"
 import "core:c/libc"
+import "core:log"
 
 USE_TRACKING_ALLOCATOR :: false
+USE_DEBUG_LOGGING :: false
 
 main :: proc() {
+	when USE_DEBUG_LOGGING {
+		context.logger = log.create_console_logger(log.Level.Debug)
+	} else {
+		context.logger = log.create_console_logger(log.Level.Fatal)
+	}
+
 	when !USE_TRACKING_ALLOCATOR {
 		_main()
 	} else {
@@ -25,6 +33,7 @@ main :: proc() {
 }
 
 _main :: proc() {
+
 	if len(os.args) < 2 {
 		fmt.println("OPM Commands:")
 		fmt.println("`opm publish` - publish the current directory")

--- a/token.odin
+++ b/token.odin
@@ -36,11 +36,6 @@ token_delete :: proc() {
 
 }
 
-// Checks if the token file exists and if so, where it is.
-token_find :: proc() {
-
-}
-
 // Conducts the following checks:
 // 0. Checks if `opm` directory exists.             Response: creates directory + file containing "none"
 // 1. Checks if .OPM_TOKEN file exists              Response: creates file containing "none"

--- a/token.odin
+++ b/token.odin
@@ -16,7 +16,7 @@ token_help :: proc() {
     fmt.println("Usage: opm token [subcommand] [value]\n")
     fmt.println("[subcommands]")
     fmt.println("opm token set [TOKEN]\t\t<-- saves token for publication")
-    fmt.println("opm token show\t\t<-- displays saved token")
+    fmt.println("opm token show\t\t\t<-- displays saved token")
     fmt.println("opm token delete\t\t<-- deletes saved token")
     fmt.println("\nFor a full list of commands please type `opm`")
 }

--- a/token.odin
+++ b/token.odin
@@ -4,11 +4,11 @@ import "core:os"
 import "core:fmt"
 
 when ODIN_OS == .Windows {
-	TOKEN_FILE := "%APPDATA%\\opm\\.OPM_TOKEN"
+    TOKEN_FILE := fmt.aprintf("%s\\%s", os.get_env("%APP_DATA%"), "opm\\.OPM_TOKEN")
 } else when ODIN_OS == .Darwin {
-    TOKEN_FILE := "~/Library/Application Support/opm/.OPM_TOKEN"
+    TOKEN_FILE := fmt.aprintf("%s/%s", os.get_env("HOME"), "Library/Application Support/opm/.OPM_TOKEN")
 } else when ODIN_OS == .Linux {
-    TOKEN_FILE := "~/.config/opm/.OPM_TOKEN"
+    TOKEN_FILE := fmt.aprintf("%s/%s", os.get_env("HOME"), ".config/opm/.OPM_TOKEN")
 }
 
 // Shows specific help menu for `opm token` subcommands.

--- a/token.odin
+++ b/token.odin
@@ -93,7 +93,6 @@ token_delete :: proc() {
 // NOTE: recoveries are priorised over panics/errors. A warning should be given as to what recovery was taken.
 conduct_token_checks :: proc() {
     directory := TOKEN_FILE[:len(TOKEN_FILE)-11]
-    fmt.println(directory)
 
     if !os.exists(directory) {
         err := os.make_directory(directory)

--- a/token.odin
+++ b/token.odin
@@ -46,6 +46,14 @@ token_set :: proc(token: string) {
 token_show :: proc() {
     conduct_token_checks()
 
+    contents, res := os.read_entire_file(TOKEN_FILE);defer delete(contents)
+
+    if !res {
+        fmt.println("Error: could not read token file")
+        return
+    }
+
+    fmt.println(contents)
 }
 
 // Replaces token file contents with "none".

--- a/token.odin
+++ b/token.odin
@@ -72,7 +72,7 @@ token_show :: proc() {
         return
     }
 
-    fmt.println(contents)
+    fmt.printf("token: %s\n", string(contents))
 }
 
 // Replaces token file contents with "none".

--- a/token.odin
+++ b/token.odin
@@ -24,16 +24,34 @@ token_help :: proc() {
 // Sets the file contents to the given input.
 token_set :: proc(token: string) {
     conduct_token_checks()
+
+    file, err := os.open(TOKEN_FILE)
+    if err != os.ERROR_NONE {
+        fmt.printf("Error: failed to open token file (%v)\n", err)
+        return
+    }
+
+    n := 0
+    n, err = os.write_string(file, token)
+
+    if err != os.ERROR_NONE {
+        fmt.printf("Error: write to token file was unsuccessful (%v)\n", err)
+        return
+    } else {
+        fmt.printf("Success: wrote %d/%d bytes!\n", n, len(token))
+    }
 }
 
 // Displays the token stored in the file.
 token_show :: proc() {
     conduct_token_checks()
+
 }
 
 // Replaces token file contents with "none".
 token_delete :: proc() {
     conduct_token_checks()
+
 }
 
 // Conducts the following checks:

--- a/token.odin
+++ b/token.odin
@@ -11,6 +11,25 @@ when ODIN_OS == .Windows {
     TOKEN_FILE := fmt.aprintf("%s/%s", os.get_env("HOME"), ".config/opm/.OPM_TOKEN")
 }
 
+token :: proc() {
+    if len(os.args) < 3 {
+        token_help()
+        return
+    }
+    
+    switch os.args[2] {
+        case "set": 
+        if len(os.args) < 4 { 
+            fmt.println("Usage: opm token set [TOKEN]")
+        } else { 
+            token_set(os.args[3]) 
+        }
+        case "show": token_show()
+        case "delete": token_delete()
+        case: token_help()
+    }
+}
+
 // Shows specific help menu for `opm token` subcommands.
 token_help :: proc() {
     fmt.println("Usage: opm token [subcommand] [value]\n")

--- a/token.odin
+++ b/token.odin
@@ -60,6 +60,11 @@ token_show :: proc() {
 token_delete :: proc() {
     conduct_token_checks()
 
+    res := os.write_entire_file(TOKEN_FILE, []u8{'n','o','n','e'})
+    if !res {
+        fmt.println("Error: could not write bytes to token file")
+        return
+    }
 }
 
 // Conducts the following checks:

--- a/token.odin
+++ b/token.odin
@@ -2,6 +2,7 @@ package opm_cli
 
 import "core:os"
 import "core:fmt"
+import "core:log"
 
 when ODIN_OS == .Windows {
     TOKEN_FILE := fmt.aprintf("%s\\%s", os.get_env("%APP_DATA%"), "opm\\.OPM_TOKEN")
@@ -20,7 +21,7 @@ token :: proc() {
     switch os.args[2] {
         case "set": 
         if len(os.args) < 4 { 
-            fmt.println("Usage: opm token set [TOKEN]")
+            log.info("Usage: opm token set [TOKEN]")
         } else { 
             token_set(os.args[3]) 
         }
@@ -44,18 +45,21 @@ token_help :: proc() {
 token_set :: proc(token: string) {
     conduct_token_checks()
 
-    file, err := os.open(TOKEN_FILE)
+    res := os.write_entire_file(TOKEN_FILE, []u8{})
+    if !res {
+        log.warn("overwritting token file data failed")
+    }
+
+    file, err := os.open(TOKEN_FILE, os.O_RDWR)
     if err != os.ERROR_NONE {
-        fmt.printf("Error: failed to open token file (%v)\n", err)
-        return
+        log.fatalf("failed to open token file (%v)", err)
     }
 
     n := 0
     n, err = os.write_string(file, token)
 
     if err != os.ERROR_NONE {
-        fmt.printf("Error: write to token file was unsuccessful (%v)\n", err)
-        return
+        log.fatalf("write to token file was unsuccessful (%v)", err)
     } else {
         fmt.printf("Success: wrote %d/%d bytes!\n", n, len(token))
     }
@@ -68,8 +72,7 @@ token_show :: proc() {
     contents, res := os.read_entire_file(TOKEN_FILE);defer delete(contents)
 
     if !res {
-        fmt.println("Error: could not read token file")
-        return
+        log.fatalf("could not read token file")
     }
 
     fmt.printf("token: %s\n", string(contents))
@@ -81,8 +84,9 @@ token_delete :: proc() {
 
     res := os.write_entire_file(TOKEN_FILE, []u8{'n','o','n','e'})
     if !res {
-        fmt.println("Error: could not write bytes to token file")
-        return
+        log.fatalf("could not write bytes to token file")
+    } else {
+        fmt.println("Success: overwrite all token data")
     }
 }
 
@@ -90,54 +94,52 @@ token_delete :: proc() {
 // 0. Checks if `opm` directory exists              Response: creates directory + file containing "none"
 // 1. Checks if .OPM_TOKEN file exists              Response: creates file containing "none"
 // 2. Checks if .OPM_TOKEN file contains nothing    Response: adds "none"
-// NOTE: recoveries are priorised over panics/errors. A warning should be given as to what recovery was taken.
 conduct_token_checks :: proc() {
     directory := TOKEN_FILE[:len(TOKEN_FILE)-11]
 
     if !os.exists(directory) {
+        log.fatal("aaaaaa")
         err := os.make_directory(directory)
         if err != os.ERROR_NONE {
-            fmt.printf("Error: unexpected error whilest recovering opm directory (%v)\n", err)
-            return
+            log.fatalf("unexpected error whilest recovering opm directory (%v)", err)
         }
 
     } else if !os.is_dir(directory) {
         err := os.remove(directory)
         if err != os.ERROR_NONE {
-            fmt.printf("Error: unexpected error whilest removing phantom opm directory (%v, file?: %v)\n", err, os.is_file(directory))
-            return
+            log.fatalf("unexpected error whilest removing file imposing as opm directory (%v, file?: %v)", err, os.is_file(directory))
         }
 
         err = os.make_directory(directory)
         if err != os.ERROR_NONE {
-            fmt.printf("Error: unexpected error whilest recovering opm directory (%v)\n", err)
-            return
+            log.fatalf("unexpected error whilest recovering opm directory (%v)", err)
         }
     }
 
     if !os.exists(TOKEN_FILE) {
         res := os.write_entire_file(TOKEN_FILE, []u8{'n','o','n','e'})
         if !res {
-            fmt.println("Error: token file recovery was not successful")
-            return
+            log.fatalf("token file recovery was not successful")
         }
 
     } else if !os.is_file(TOKEN_FILE) {
-        // Delete "TOKEN_FILE", create file
+        err := os.remove(TOKEN_FILE)
+        if err != os.ERROR_NONE {
+            log.fatalf("unexpected error whilest removing directory imposing token file (%v, file?: %v)", err, os.is_file(TOKEN_FILE))
+        }
         res := os.write_entire_file(TOKEN_FILE, []u8{'n','o','n','e'})
         if !res {
-            fmt.println("Error: token file recovery was not successful")
-            return
+            log.fatalf("token file recovery was not successful")
         }
     } 
 
     data, res := os.read_entire_file(TOKEN_FILE);defer delete(data)
     
     if !res {
-        fmt.println("Warning: unable to read token file contents... This may impact other functions!")
+        log.warn("token file is not readable. This may impact other functions.")
     } else {
         if string(data) == "none" {
-            fmt.println("Warning: no token was found... This may impact other functions!")
+            log.warn("token file doesn't contain a valid token. This may impact other functions.")
         }
     }
 }

--- a/token.odin
+++ b/token.odin
@@ -1,0 +1,36 @@
+package opm_cli
+
+import "core:os"
+
+when ODIN_OS == .Windows {
+	TOKEN_FILE := "%APPDATA%\\opm\\.OPM_TOKEN"
+} else when ODIN_OS == .Darwin {
+    TOKEN_FILE := "~/Library/Application Support/opm/.OPM_TOKEN"
+} else when ODIN_OS == .Linux {
+    TOKEN_FILE := "~/.config/opm/.OPM_TOKEN"
+}
+
+// Shows specific help menu for `opm token` subcommands.
+token_help :: proc() {
+
+}
+
+// Sets the file contents to the given input.
+token_set :: proc(token string) {
+
+}
+
+// Displays the token stored in the file.
+token_show :: proc() {
+
+}
+
+// Replaces token file contents with "none".
+token_delete :: proc() {
+
+}
+
+// Checks if the token file exists and if so, where it is.
+token_find :: proc() {
+
+}

--- a/token.odin
+++ b/token.odin
@@ -1,6 +1,7 @@
 package opm_cli
 
 import "core:os"
+import "core:fmt"
 
 when ODIN_OS == .Windows {
 	TOKEN_FILE := "%APPDATA%\\opm\\.OPM_TOKEN"
@@ -12,7 +13,12 @@ when ODIN_OS == .Windows {
 
 // Shows specific help menu for `opm token` subcommands.
 token_help :: proc() {
-
+    fmt.println("Usage: opm token [subcommand] [value]\n")
+    fmt.println("[subcommands]")
+    fmt.println("opm token set [TOKEN]\t\t<-- saves token for publication")
+    fmt.println("opm token show\t\t<-- displays saved token")
+    fmt.println("opm token delete\t\t<-- deletes saved token")
+    fmt.println("\nFor a full list of commands please type `opm`")
 }
 
 // Sets the file contents to the given input.
@@ -33,4 +39,13 @@ token_delete :: proc() {
 // Checks if the token file exists and if so, where it is.
 token_find :: proc() {
 
+}
+
+// Conducts the following checks:
+// 0. Checks if `opm` directory exists.             Response: creates directory + file containing "none"
+// 1. Checks if .OPM_TOKEN file exists              Response: creates file containing "none"
+// 2. Checks if .OPM_TOKEN file contains anything   Response: informs the user
+// NOTE: recoveries are priorised over panics/errors. A warning should be given as to what recovery was taken.
+conduct_token_checks :: proc() {
+    
 }


### PR DESCRIPTION
## Related Issues/PR
- close #2 

## Change list
- [x] Added `opm token set [TOKEN]`
- [x] Added `opm token show`
- [x] Added `opm token delete`
- [x] `opm token` now shows a help message
- [x] Removed original `opm token` code in main
- [x] Added config locations: (**Windows**: `%APPDATA%\opm\.OPM_TOKEN`, **MacOS**: `$HOME/Library/Application Support/opm/.OPM_TOKEN`, **Linux**: `$HOME/.config/opm/.OPM_TOKEN`)
- [x] Added `get_token` (for internal use)
- [x] Switched `publish` to use `get_token` instead of `get_env`
- [ ] Add new token subcommands to the opm help message
- [ ] Request password from user for all token functions (to encrypt/decrypt)
- [ ] Encrypt the token stored in the file

